### PR TITLE
refactor(dom): closeOnBackdropClick als wiederverwendbaren helper exp…

### DIFF
--- a/public/script/shared/dom.ts
+++ b/public/script/shared/dom.ts
@@ -51,3 +51,11 @@ export const cancelDeleteBtn = requiredElement<HTMLButtonElement>("cancelDeleteB
 export const profileName = optionalElement<HTMLSpanElement>("profileName");
 export const authButton = optionalElement<HTMLButtonElement>("authButton");
 export const coinDisplay = optionalElement<HTMLSpanElement>("coinDisplay");
+
+export function closeOnBackdropClick(modal: HTMLDialogElement, onClose?: () => void): void {
+  modal.addEventListener("click", (e) => {
+    if (e.target === modal) {
+      onClose ? onClose() : modal.close();
+    }
+  });
+}


### PR DESCRIPTION
## closeOnBackdropClick in dom.ts auslagern

`closeOnBackdropClick()` war bisher in `inventory.ts` definiert, obwohl es ein generischer Modal-Helfer ist.
Die Funktion wurde nach `shared/dom.ts` verschoben und exportiert, sodass sie von allen Modulen genutzt werden kann.