### PR TITLE
Refactor fetchCurrentUser as reusable helper export

### DIFF
--- a/public/script/shared/supabase-client.ts
+++ b/public/script/shared/supabase-client.ts
@@ -4,3 +4,17 @@ const SUPABASE_URL: string = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_PUBLISHABLE_KEY: string = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
 export const supabaseClient = createClient(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
+
+export async function fetchCurrentUser() {
+  const {
+    data: { user },
+    error,
+  } = await supabaseClient.auth.getUser();
+
+  if (error) {
+    console.error("Fehler beim Laden des Users:", error.message);
+    return null;
+  }
+
+  return user;
+}


### PR DESCRIPTION
## fetchCurrentUser in supabase-client.ts auslagern

`fetchCurrentUser()` war bisher in `inventory.ts` definiert, gehört aber zur Auth-Schicht.
Die Funktion wurde nach `shared/supabase-client.ts` verschoben und exportiert.