### PR TITLE
feat(validation): add client-side name input validation #31

### DIFF
--- a/public/css/name-input-validation.css
+++ b/public/css/name-input-validation.css
@@ -1,0 +1,45 @@
+.add-row.name-input-validation-host {
+    position: relative;
+    overflow: visible;
+}
+
+.name-input-field-error {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(100% + 10px);
+    z-index: 1;
+    pointer-events: none;
+    margin: 0;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid rgba(231, 76, 60, 0.28);
+    border-radius: calc(var(--radius-md) + 2px);
+    background: rgba(255, 244, 242, 0.96);
+    box-shadow: 0 12px 28px rgba(138, 28, 17, 0.12);
+    color: var(--color-error, #e74c3c);
+    font-size: var(--text-sm, 0.875rem);
+    font-weight: 600;
+    line-height: 1.4;
+    letter-spacing: 0.01em;
+    text-align: left;
+}
+
+.name-input-field-error::before {
+    content: "Invalid input";
+    display: block;
+    margin-bottom: 0.2rem;
+    color: rgba(138, 28, 17, 0.82);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.name-input-field-error[hidden] {
+    display: none;
+}
+
+#nameInput.name-input-invalid {
+    border: 1px solid var(--color-error, #e74c3c);
+    box-shadow: 0 0 0 4px rgba(231, 76, 60, 0.14);
+}

--- a/public/html/main.html
+++ b/public/html/main.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../css/buttons.css">
     <link rel="stylesheet" href="../css/layout.css">
     <link rel="stylesheet" href="../css/inventory.css">
+    <link rel="stylesheet" href="../css/name-input-validation.css">
     <link rel="stylesheet" href="../css/modals.css">
     <link rel="stylesheet" href="../css/legal-links.css">
     <link rel="icon" type="image/png" href="assets/favicon.png">

--- a/public/script/names/name-input-validation.ts
+++ b/public/script/names/name-input-validation.ts
@@ -1,0 +1,107 @@
+import { input } from "../shared/dom.js";
+import { validateName } from "../shared/validation.js";
+
+type NameValidationResult = ReturnType<typeof validateName>;
+
+const ERROR_ELEMENT_ID = "nameInputFieldError";
+const ERROR_ELEMENT_CLASS = "name-input-field-error";
+const HOST_ELEMENT_CLASS = "name-input-validation-host";
+const INVALID_INPUT_CLASS = "name-input-invalid";
+
+function getInputRow(): HTMLDivElement {
+  const row = input.closest<HTMLDivElement>(".add-row");
+
+  if (!row) {
+    throw new Error("Missing .add-row container for #nameInput.");
+  }
+
+  return row;
+}
+
+function getExistingErrorElement(): HTMLParagraphElement | null {
+  return document.getElementById(ERROR_ELEMENT_ID) as HTMLParagraphElement | null;
+}
+
+function createErrorElement(): HTMLParagraphElement {
+  const inputRow = getInputRow();
+  const errorElement = document.createElement("p");
+
+  inputRow.classList.add(HOST_ELEMENT_CLASS);
+
+  errorElement.id = ERROR_ELEMENT_ID;
+  errorElement.className = ERROR_ELEMENT_CLASS;
+  errorElement.setAttribute("role", "alert");
+  errorElement.setAttribute("aria-live", "polite");
+  errorElement.hidden = true;
+
+  inputRow.appendChild(errorElement);
+  input.setAttribute("aria-describedby", ERROR_ELEMENT_ID);
+
+  return errorElement;
+}
+
+function getErrorElement(): HTMLParagraphElement {
+  const existingElement = getExistingErrorElement();
+
+  if (existingElement) {
+    return existingElement;
+  }
+
+  return createErrorElement();
+}
+
+function updateErrorMessage(message: string): void {
+  const errorElement = getErrorElement();
+
+  errorElement.textContent = message;
+  errorElement.hidden = message.length === 0;
+}
+
+function setInputInvalidState(isInvalid: boolean): void {
+  input.classList.toggle("invalid", isInvalid);
+  input.classList.toggle(INVALID_INPUT_CLASS, isInvalid);
+
+  if (isInvalid) {
+    input.setAttribute("aria-invalid", "true");
+    return;
+  }
+
+  input.removeAttribute("aria-invalid");
+}
+
+export function showNameInputError(message: string): void {
+  updateErrorMessage(message);
+  setInputInvalidState(true);
+}
+
+export function clearNameInputError(): void {
+  updateErrorMessage("");
+  setInputInvalidState(false);
+}
+
+export function validateNameInput(rawName: string): NameValidationResult {
+  const result = validateName(rawName);
+
+  if (result.valid) {
+    clearNameInputError();
+    return result;
+  }
+
+  showNameInputError(result.message);
+  return result;
+}
+
+export function initNameInputValidation(): void {
+  getErrorElement();
+
+  input.addEventListener("input", () => {
+    const currentValue = input.value.trim();
+
+    if (!currentValue) {
+      clearNameInputError();
+      return;
+    }
+
+    validateNameInput(currentValue);
+  });
+}

--- a/public/script/names/name-list.ts
+++ b/public/script/names/name-list.ts
@@ -2,6 +2,11 @@ import { MAX_ITEMS, MIN_ITEMS } from "../shared/constants.js";
 import { addBtn, emptyHint, errorHint, input, list } from "../shared/dom.js";
 import { validateName } from "../shared/validation.js";
 import { generateWheel, getSegmentColor } from "../wheel/renderer.js";
+import {
+  clearNameInputError,
+  initNameInputValidation,
+  validateNameInput,
+} from "./name-input-validation.js";
 import { nameState } from "./name-state.js";
 
 let errorTimer: ReturnType<typeof setTimeout> | null = null;
@@ -107,14 +112,10 @@ function handleRemove(index: number, item: HTMLLIElement): void {
 }
 
 export function addName(rawName: string): void {
-  input.classList.remove("invalid");
-
-  const validation = validateName(rawName);
+  const validation = validateNameInput(rawName);
 
   if (!validation.valid) {
-    input.classList.add("invalid");
     input.focus();
-    showError(validation.message);
     return;
   }
 
@@ -124,6 +125,7 @@ export function addName(rawName: string): void {
   }
 
   input.value = "";
+  clearNameInputError();
   input.focus();
 }
 
@@ -149,6 +151,7 @@ export function initNameList(): void {
 
   nameState.subscribe(renderNames);
   nameState.setNames(initialNames);
+  initNameInputValidation();
 }
 
 export function initExistingItems(): void {


### PR DESCRIPTION
## Summary

Adds client-side validation for the name input in the wheel name list.

Invalid special characters are now detected directly while typing. When the input is invalid, an error message is shown above the field and the input is highlighted visually.

## Changes

- add dedicated name-input validation module
- validate invalid characters directly in the name input
- show inline error message above the input field
- highlight invalid input with a red error state
- prevent the name list from shifting when the error message appears
- extract error styling into a dedicated CSS file
- keep the implementation isolated to the name-list feature

## Files

- `public/script/names/name-input-validation.ts`
- `public/script/names/name-list.ts`
- `public/css/name-input-validation.css`
- `public/html/main.html`

## Validation

- `npm run build --workspace public`

## Notes

This PR replaces an earlier branch that accidentally included unrelated older changes.
This branch contains only the intended changes for the name input validation feature.