### PR TITLE
Update winner toast and upgrade Supabase packages

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.104.0",
+    "@supabase/supabase-js": "^2.105.3",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^4.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     "api": {
       "version": "1.0.0",
       "dependencies": {
-        "@supabase/supabase-js": "^2.104.0",
+        "@supabase/supabase-js": "^2.105.3",
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^4.18.2",
@@ -583,9 +583,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.104.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.0.tgz",
-      "integrity": "sha512-Vs0ndL+s5an7rOmXtS/nbYnGXL8m+KXlCSrPIcw9bR96ma6qyLYILnE6syuM+rpDnf+Tg4PVNxNB2+oDwoy6mA==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.3.tgz",
+      "integrity": "sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -595,9 +595,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.104.0",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.104.0.tgz",
-      "integrity": "sha512-O8EyEz/RT1kfWhyJNpVc/VbLeBsohHGBVif/CI83zoMB+Iul/t/NIekH1/7RsH6kuO+b2D4wJhfiaW8Qr47sRg==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.3.tgz",
+      "integrity": "sha512-KyutUwLLUZ9fRXsiFACL6lq7akBVHFl0fnqQnrxjbsPco8jeb4EyirQuvr52QCLnikzjMRC0uxAHOSM54aDrZA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -607,15 +607,15 @@
       }
     },
     "node_modules/@supabase/phoenix": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
-      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
+      "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==",
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.104.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.104.0.tgz",
-      "integrity": "sha512-ynylEq6wduQEycj6pL3P+/yIfDQ+CTnBC5I6p+PzcAO2ybj9coAITVtMfboi+g/dacgMslN5MH73rXsRMB29+Q==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.3.tgz",
+      "integrity": "sha512-jFVYRHcri0ZMcTzKpQ2r2wWOB8/rPsbj92kxmCmVJUiRrdgiMtuYlkS06Fhs8UJZhEOL0UpGhh06XDwh8JwtBQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -625,12 +625,12 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.104.0",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.104.0.tgz",
-      "integrity": "sha512-9fUVDoTVAhn7a79+AmEx+asUlRtf2yBrji7TQckcKn/WK4hvAA9Lia9er+lnhuz3WNiF1x6kkA4x7bRCJrU+KA==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.3.tgz",
+      "integrity": "sha512-L+qPiJlq1RKh3QD2fORGCFo2RKDKlvG9mjvPtUEQJ2tMixrx70VIV6j8BdWzQkbc1Nao6mvTWajyDhX3TFgljw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/phoenix": "^0.4.0",
+        "@supabase/phoenix": "^0.4.1",
         "@types/ws": "^8.18.1",
         "tslib": "2.8.1",
         "ws": "^8.18.2"
@@ -640,9 +640,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.104.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.0.tgz",
-      "integrity": "sha512-s2NHtuAWb9nldJ/fS62WnJE6edvCWn31rrO+FJKlAohs99qdVgtLegUReTU2H9WnZiQlVqaBtu386wt6/6lrRw==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.3.tgz",
+      "integrity": "sha512-M7oPCCcHim/FsR6rKIs10Nd9mW051N2SQvA27jiVLa7oQMFFb7faX5dCQRV4GS5QeFsBcV5J/fWl4Ppoaw8cBQ==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -653,16 +653,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.104.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.104.0.tgz",
-      "integrity": "sha512-hILwhIjCB53G31jlHUe73NDEmrXudcjcYlVRuvNfEhzf0gyFQaFf7j6rd1UGmYZkFMOg//DFE8Iy9ZbNEgosVw==",
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.3.tgz",
+      "integrity": "sha512-5Dm9+I61LAWwjw+0zcqXhSmTxUJaYHBPyHwMCIBH4TBUNwDn2pYUIsi6oUu0I5r9HtLtaFl7w4wa+DV9gRsbDg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.104.0",
-        "@supabase/functions-js": "2.104.0",
-        "@supabase/postgrest-js": "2.104.0",
-        "@supabase/realtime-js": "2.104.0",
-        "@supabase/storage-js": "2.104.0"
+        "@supabase/auth-js": "2.105.3",
+        "@supabase/functions-js": "2.105.3",
+        "@supabase/postgrest-js": "2.105.3",
+        "@supabase/realtime-js": "2.105.3",
+        "@supabase/storage-js": "2.105.3"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/public/script/wheel/winner.ts
+++ b/public/script/wheel/winner.ts
@@ -3,6 +3,7 @@ import { getNames, removeNameByIndex } from "../names/name-list.js";
 import { stopDrumRoll } from "./sound.js";
 import { getCurrentRotation, resetWheelRotation } from "./spin.js";
 import { refreshCoinDisplay } from "../profile/profiles.js";
+import { showToast } from "../shared/toast.js";
 
 export function getWinningSegmentIndexForRotation(rotation: number, segmentCount: number): number {
   const normalizedRotation = ((rotation % 360) + 360) % 360;
@@ -88,6 +89,7 @@ function startConfetti(): void {
 }
 
 let lastWinnerIndex: number = -1;
+let lastWinnerName: string = "";
 
 export function announceWinner(segmentCount: number, spinToken: string): void {
   stopDrumRoll();
@@ -95,6 +97,7 @@ export function announceWinner(segmentCount: number, spinToken: string): void {
   lastWinnerIndex = getWinningSegmentIndex(segmentCount);
   const names = getNames();
   const winnerName = names[lastWinnerIndex];
+  lastWinnerName = winnerName;
 
   console.log("[SPIN] 🏆 Gewinner ermittelt:", { winnerName, spinToken: spinToken || "LEER" });
 
@@ -124,12 +127,18 @@ export function setupWinnerModal(): void {
     modal.classList.add("hidden");
     resetWheelRotation();
   });
-
+  
   removeBtn.addEventListener("click", () => {
     if (lastWinnerIndex < 0) return;
 
+    const removedName = lastWinnerName;
     removeNameByIndex(lastWinnerIndex);
     modal.classList.add("hidden");
     resetWheelRotation();
+
+    showToast({
+      message: `"${removedName}" wurde erfolgreich aus dem Rad entfernt.`,
+      type: "success"
+    })
   });
 }


### PR DESCRIPTION
## Summary
- add a success toast after removing the winning name from the wheel
- persist the removed winner name before removing it from the list
- bump `@supabase/supabase-js` from `2.104.0` to `2.105.3`
- refresh the lockfile for the Supabase dependency update

## Files changed
- public/script/wheel/winner.ts
- api/package.json
- package-lock.json

## Notes
- the winner removal flow now shows a clearer user confirmation message
- the dependency bump updates related Supabase packages in the lockfile