### PR TITLE
Refactor/spin separation

### DIFF
--- a/public/script/app/main.ts
+++ b/public/script/app/main.ts
@@ -22,6 +22,7 @@ import { initWinnerModal } from "../wheel/winner.js";
 import { createRoom, joinRoom, spinRoom, closeRoom, subscribeToRoom, unsubscribeFromRoom } from "../room.js";
 import { showToast } from "../shared/toast.js";
 import type { Direction } from "../shared/types.js";
+import { MIN_SPIN_ROTATIONS } from "../shared/constants.js";
 import { initShop } from "../shop/shop.js";
 
 let activeRoomKey: string | null = null;
@@ -126,7 +127,7 @@ function handleRoomSpinEvent(lastSpin: number): void {
   if (isHost) return; // host already spun directly from POST response
   lockSpinButtons();
   const names = getNames();
-  const totalSteps = Math.round(lastSpin * getMultiplier());
+  const totalSteps = Math.round(MIN_SPIN_ROTATIONS * getMultiplier()) + lastSpin;
   spinWheel(totalSteps, 'right', '', names);
 }
 
@@ -137,7 +138,7 @@ async function handleRoomSpinClick(direction: Direction): Promise<void> {
   try {
     const names = getNames();
     const { ranNum, spinToken } = await spinRoom(activeRoomKey, names);
-    const totalSteps = Math.round(ranNum * getMultiplier());
+    const totalSteps = Math.round(MIN_SPIN_ROTATIONS * getMultiplier()) + ranNum;
     spinWheel(totalSteps, direction, spinToken, names);
   } catch (error) {
     console.error('[ROOM] Spin fehlgeschlagen:', error);

--- a/public/script/app/main.ts
+++ b/public/script/app/main.ts
@@ -12,9 +12,10 @@ import { nameState } from "../names/name-state.js";
 import { initShareFeature } from "../names/share-name-list.js";
 import { initProfileUI } from "../profile/profiles.js";
 import {
-  initMultiplierSlider, initWheelControls, spinWheel,
-  setSpinOverride, lockSpinButtons, unlockSpinButtons, getMultiplier,
+  initWheelControls, spinWheel,
+  setSpinOverride, lockSpinButtons, unlockSpinButtons,
 } from "../wheel/spin.js";
+import { initMultiplierSlider, getMultiplier } from "../wheel/multiplier.js";
 import { initVolumeSlider } from "../wheel/volume.js";
 import { preloadStaticSounds } from "../wheel/sound.js";
 import { initWinnerModal } from "../wheel/winner.js";
@@ -124,8 +125,9 @@ function clearRoom(): void {
 function handleRoomSpinEvent(lastSpin: number): void {
   if (isHost) return; // host already spun directly from POST response
   lockSpinButtons();
+  const names = getNames();
   const totalSteps = Math.round(lastSpin * getMultiplier());
-  spinWheel(totalSteps, 'right', '');
+  spinWheel(totalSteps, 'right', '', names);
 }
 
 // Host only: POST → spin directly (token guaranteed, no race condition)
@@ -136,7 +138,7 @@ async function handleRoomSpinClick(direction: Direction): Promise<void> {
     const names = getNames();
     const { ranNum, spinToken } = await spinRoom(activeRoomKey, names);
     const totalSteps = Math.round(ranNum * getMultiplier());
-    spinWheel(totalSteps, direction, spinToken);
+    spinWheel(totalSteps, direction, spinToken, names);
   } catch (error) {
     console.error('[ROOM] Spin fehlgeschlagen:', error);
     unlockSpinButtons();

--- a/public/script/names/share-name-list.ts
+++ b/public/script/names/share-name-list.ts
@@ -1,5 +1,5 @@
 import { shareBtn } from "../shared/dom.js";
-import { getMultiplier, setMultiplierSlider, updateMultiplierDisplay } from "../wheel/spin.js";
+import { getMultiplier, setMultiplierSlider, updateMultiplierDisplay } from "../wheel/multiplier.js";
 import { getNames, replaceNames } from "./name-list.js";
 import { showToast } from "../shared/toast.js";
 

--- a/public/script/shared/types.ts
+++ b/public/script/shared/types.ts
@@ -24,6 +24,7 @@ export interface SpinConfig {
   stepAngle: number;
   segmentCount: number;
   spinToken: string;
+  names: string[];
 }
 
 export type SpinHandler = (direction: Direction) => Promise<void>;

--- a/public/script/wheel/multiplier.ts
+++ b/public/script/wheel/multiplier.ts
@@ -1,0 +1,21 @@
+import { multiplierSlider, multiplierValue } from "../shared/dom.js";
+import { DEFAULT_MULTIPLIER } from "../shared/constants.js";
+
+export function setMultiplierSlider(multiplier: number): void {
+  multiplierSlider.value = `${multiplier}`;
+}
+
+export function updateMultiplierDisplay(): void {
+  if (!multiplierSlider || !multiplierValue) return;
+  multiplierValue.textContent = multiplierSlider.value;
+}
+
+export function initMultiplierSlider(): void {
+  multiplierSlider?.addEventListener("input", updateMultiplierDisplay);
+  updateMultiplierDisplay();
+}
+
+export function getMultiplier(): number {
+  const value = parseFloat(multiplierSlider.value);
+  return Number.isNaN(value) ? DEFAULT_MULTIPLIER : value;
+}

--- a/public/script/wheel/spin.ts
+++ b/public/script/wheel/spin.ts
@@ -3,7 +3,6 @@ import {
   getRemoveBtn,
   input,
   multiplierSlider,
-  multiplierValue,
   resetBtn,
   spinLeftBtn,
   spinRightBtn,
@@ -11,8 +10,9 @@ import {
 } from "../shared/dom.js";
 import { playTickSound, playDrumRoll, stopDrumRoll, playCymbalCrash } from "./sound.js";
 import { fetchRandomNumber } from "../api/client-api.js";
-import { getSegmentCount, getNames } from "../names/name-list.js";
-import { announceWinner } from "./winner.js";
+import { getNames } from "../names/name-list.js";
+import { announceWinner, resolveWinner } from "./winner.js";
+import { getMultiplier } from "./multiplier.js";
 import {
   FULL_CIRCLE_DEG,
   POINTER_OFFSET_DEG,
@@ -24,7 +24,6 @@ import {
   SPIN_EASE_EXPONENT,
   SPIN_DISABLED_OPACITY,
   MIN_SPIN_ROTATIONS,
-  DEFAULT_MULTIPLIER,
 } from "../shared/constants.js";
 import type { Direction, SpinConfig, SpinHandler, SpinElement, SpinFrameState } from "../shared/types.js";
 
@@ -92,13 +91,6 @@ function computeVelocity(progress: number): number {
   return MIN_SPIN_VELOCITY + (MAX_SPIN_VELOCITY - MIN_SPIN_VELOCITY) * Math.pow(1 - decelRatio, SPIN_EASE_EXPONENT);
 }
 
-function resolveWinner(rotation: number, config: SpinConfig): string {
-  const names = getNames();
-  const pointerAngle = ((POINTER_OFFSET_DEG - rotation) % FULL_CIRCLE_DEG + FULL_CIRCLE_DEG) % FULL_CIRCLE_DEG;
-  const winnerIndex = Math.floor(pointerAngle / config.stepAngle) % config.segmentCount;
-  return names[winnerIndex] ?? names[0];
-}
-
 function finishSpin(config: SpinConfig): void {
   stopDrumRoll();
   playCymbalCrash();
@@ -132,34 +124,34 @@ function animateSpin(config: SpinConfig): void {
   requestAnimationFrame(() => runSpinFrame(state, config));
 }
 
-export function spinWheel(totalSteps: number, direction: Direction, spinToken: string): void {
+export function spinWheel(totalSteps: number, direction: Direction, spinToken: string, names: string[]): void {
   spinCancelled = false;
-  const segmentCount = getSegmentCount();
-  if (segmentCount < MIN_ITEMS) return;
+  if (names.length < MIN_ITEMS) return;
 
   const clampedSteps = Math.max(Math.floor(totalSteps), MIN_SPIN_ROTATIONS);
 
   const config: SpinConfig = {
     totalSteps: clampedSteps,
     direction,
-    stepAngle: FULL_CIRCLE_DEG / segmentCount,
-    segmentCount,
+    stepAngle: FULL_CIRCLE_DEG / names.length,
+    segmentCount: names.length,
     spinToken,
+    names,
   };
 
   animateSpin(config);
 }
 
 export async function spinWheelWithRandomSteps(direction: Direction): Promise<void> {
-  if (getSegmentCount() < MIN_ITEMS) return;
+  const names = getNames();
+  if (names.length < MIN_ITEMS) return;
 
   lockSpinButtons();
 
   try {
-    const names = getNames();
     const multiplier = getMultiplier();
     const { ranNum: rawSteps, spinToken } = await fetchRandomNumber(names, currentRotation, direction, multiplier);
-    spinWheel(Math.floor(rawSteps * multiplier), direction, spinToken);
+    spinWheel(Math.floor(rawSteps * multiplier), direction, spinToken, names);
   } catch (error) {
     console.error("[SPIN] Fehler beim Spin:", error);
     unlockSpinButtons();
@@ -173,25 +165,6 @@ export function resetWheelRotation(): void {
   updateWheelRotation();
   unlockSpinButtons();
   stopDrumRoll();
-}
-
-export function setMultiplierSlider(multiplier: number): void {
-  multiplierSlider.value = `${multiplier}`;
-}
-
-export function updateMultiplierDisplay(): void {
-  if (!multiplierSlider || !multiplierValue) return;
-  multiplierValue.textContent = multiplierSlider.value;
-}
-
-export function initMultiplierSlider(): void {
-  multiplierSlider?.addEventListener("input", updateMultiplierDisplay);
-  updateMultiplierDisplay();
-}
-
-export function getMultiplier(): number {
-  const value = parseFloat(multiplierSlider.value);
-  return Number.isNaN(value) ? DEFAULT_MULTIPLIER : value;
 }
 
 export function getCurrentRotation(): number {

--- a/public/script/wheel/spin.ts
+++ b/public/script/wheel/spin.ts
@@ -151,7 +151,7 @@ export async function spinWheelWithRandomSteps(direction: Direction): Promise<vo
   try {
     const multiplier = getMultiplier();
     const { ranNum: rawSteps, spinToken } = await fetchRandomNumber(names, currentRotation, direction, multiplier);
-    spinWheel(Math.floor(rawSteps * multiplier), direction, spinToken, names);
+    spinWheel(Math.round(MIN_SPIN_ROTATIONS * multiplier) + rawSteps, direction, spinToken, names);
   } catch (error) {
     console.error("[SPIN] Fehler beim Spin:", error);
     unlockSpinButtons();

--- a/public/script/wheel/winner.ts
+++ b/public/script/wheel/winner.ts
@@ -5,6 +5,14 @@ import { resetWheelRotation } from "./spin.js";
 import { refreshCoinDisplay } from "../profile/profiles.js";
 import { showToast } from "../shared/toast.js";
 import { winnerModal, closeWinnerModalBtn, removeWinnerBtn, winnerText, confettiCanvas } from "../shared/dom.js";
+import { POINTER_OFFSET_DEG, FULL_CIRCLE_DEG } from "../shared/constants.js";
+import type { SpinConfig } from "../shared/types.js";
+
+export function resolveWinner(rotation: number, config: SpinConfig): string {
+  const pointerAngle = ((POINTER_OFFSET_DEG - rotation) % FULL_CIRCLE_DEG + FULL_CIRCLE_DEG) % FULL_CIRCLE_DEG;
+  const winnerIndex = Math.floor(pointerAngle / config.stepAngle) % config.segmentCount;
+  return config.names[winnerIndex] ?? config.names[0];
+}
 
 export function displayWinnerModal(winnerName: string): void {
   if (!winnerModal || !winnerText) return;

--- a/server/src/services/spin-service.ts
+++ b/server/src/services/spin-service.ts
@@ -9,8 +9,8 @@ import {
 } from "../repositories/profile-repository";
 import { insertSpinToken, findValidSpinToken, markSpinTokenUsed } from "../repositories/room-repository";
 
-const MIN_ROTATION_DEGREE = 140;
-const MAX_ROTATION_DEGREE = 900;
+const MIN_ROTATION_DEGREE = 0;
+const MAX_ROTATION_DEGREE = 359;
 
 export type AwardCoinsResult = {
     spinnerCoins: number;


### PR DESCRIPTION
## Was wurde geändert?

Zwei unabhängige Probleme wurden auf diesem Branch behoben.

### Refactoring: `spin.ts` hatte zu viele Verantwortlichkeiten

`spin.ts` enthielt neben dem Animationsloop auch Gewinner-Berechnung und Multiplier-Slider-Logik, die dort nicht hingehören.

- **`multiplier.ts` (neu)** — `getMultiplier`, `setMultiplierSlider`, `updateMultiplierDisplay`, `initMultiplierSlider` ausgelagert
- **`winner.ts`** — `resolveWinner()` dorthin verschoben, wo die Gewinner-Logik hingehört
- **`SpinConfig`** — `names: string[]` als Snapshot beim Spin-Start hinzugefügt; `resolveWinner` liest nicht mehr live `getNames()` — verhindert falschen Gewinner bei gleichzeitiger Name-Änderung (z.B. Room-Sync)

### Fix: Server-Zufallszahl wurde komplett ignoriert

Der Server gab `crypto.randomInt(140, 900)` zurück, der Client erzwang aber ein Minimum von `1800°` — `Math.max(ranNum, 1800)` überschrieb die Zufallszahl immer. Das Rad drehte sich dadurch stets exakt 5 Umdrehungen und landete immer an derselben Position.

- **Server:** Range auf `0–359°` (reiner Landungswinkel)
- **Client:** `totalSteps = round(MIN_SPIN_ROTATIONS × multiplier) + rawSteps` statt `Math.max`

### Betroffene Dateien

| Datei | Änderung |
|---|---|
| `wheel/multiplier.ts` | neu |
| `wheel/spin.ts` | Multiplier + `resolveWinner` entfernt, Formel gefixt |
| `wheel/winner.ts` | `resolveWinner` aufgenommen |
| `shared/types.ts` | `names` zu `SpinConfig` |
| `app/main.ts` | Imports + `spinWheel`-Aufrufe angepasst |
| `names/share-name-list.ts` | Import umgehängt |
| `server/src/services/spin-service.ts` | Range `0–359` |
