### PR TITLE
Bugfix/382 user remains visible in room after logout

### DIFF
--- a/public/script/profile/profiles.ts
+++ b/public/script/profile/profiles.ts
@@ -7,6 +7,7 @@ import { isSpinning } from "../wheel/spin";
 import { showToast } from "../shared/toast";
 import { getUserCoins, getUserProfile as fetchUserProfileFromApi } from "../api/user-api";
 import { notifyAccountChanged } from "../shared/auth-channel";
+import { activeRoomKey, executeLeaveRoom, showSwitchRoomConfirm } from "../room";
 
 export const profileName = optionalElement<HTMLSpanElement>("user-profile-name");
 export const authButton = optionalElement<HTMLButtonElement>("auth-button");
@@ -59,10 +60,14 @@ function applyAuthenticatedState(profile: ProfileData | null): void {
   });
 
   authButton.textContent = "Logout";
-  authButton.addEventListener("click", async () => {
-    await supabaseClient.auth.signOut();
-    notifyAccountChanged();
-    window.location.href = "/login.html";
+
+  authButton.addEventListener("click", () => {
+    showSwitchRoomConfirm("Wirklich ausloggen?", async () => {
+      if (activeRoomKey) await executeLeaveRoom();
+      await supabaseClient.auth.signOut();
+      notifyAccountChanged();
+      window.location.href = "/login.html";
+    });
   });
 }
 

--- a/public/script/room.ts
+++ b/public/script/room.ts
@@ -143,6 +143,18 @@ export function subscribeToRoom(
 
       },
     )
+    .on(
+      'postgres_changes',
+      {
+        event: 'DELETE',
+        schema: 'public',
+        table: 'rooms',
+        filter: `room_key=eq.${roomKey}`,
+      },
+      // Host-Leave löscht die Zeile direkt nach dem players=[]-Update; das DELETE
+      // ist das verlässliche, endgültige Signal und braucht kein Racing gegen das UPDATE.
+      () => { onClose?.(); },
+    )
     .subscribe();
 }
 

--- a/public/script/room.ts
+++ b/public/script/room.ts
@@ -529,7 +529,7 @@ function updateBulkButtonState(players: string[]): void {
   }
 }
 
-async function executeLeaveRoom(): Promise<void> {
+export async function executeLeaveRoom(): Promise<void> {
   const wasHost = isHost;
   const roomKey = activeRoomKey;
   clearRoom(); // unsubscribe first so we don't receive our own close event
@@ -613,7 +613,7 @@ let pendingRoomAction: (() => Promise<void>) | null = null;
 const leaveRoomConfirmModal = optionalElement<HTMLDialogElement>("leave-room-confirm-modal");
 const leaveRoomConfirmMessage = optionalElement<HTMLParagraphElement>("leave-room-confirm-message");
 
-function showSwitchRoomConfirm(message: string, action: () => Promise<void>): void {
+export function showSwitchRoomConfirm(message: string, action: () => Promise<void>): void {
   if (leaveRoomConfirmMessage) leaveRoomConfirmMessage.textContent = message;
   pendingRoomAction = action;
   leaveRoomConfirmModal?.showModal();

--- a/supabase/migrations/22_rooms_replica_identity_full.sql
+++ b/supabase/migrations/22_rooms_replica_identity_full.sql
@@ -1,0 +1,10 @@
+-- =========================================================
+-- FILE: supabase/migrations/22_rooms_replica_identity_full.sql
+-- PURPOSE: DELETE-Events auf public.rooms enthalten per Default nur die
+--          Primary-Key-Spalte (id) im "old record". Damit Realtime-Clients
+--          DELETEs per room_key filtern können (z.B. um zuverlässig zu
+--          erkennen, dass der Host den Room geschlossen hat), muss die
+--          Tabelle die vollständige alte Zeile in die WAL schreiben.
+-- =========================================================
+
+alter table public.rooms replica identity full;


### PR DESCRIPTION
### Fix:

Logout ruft jetzt vor dem Signout die bestehende "Room verlassen"-Logik per `executeLeaveRoom()` auf mit Bestätigungsdialog, und da der Server beim Host-Close die Room-Zeile per DELETE löscht statt nur zu updaten, hört der Client zusätzlich auf DELETE-Events (samt REPLICA IDENTITY FULL-Migration, damit der `room_key`-Filter dabei überhaupt greift), damit auch dieses Signal zuverlässig bei den anderen Spielern ankommt.