### PR TITLE
fix(room): Power Slider für Gäste nach Reset/WinnerModal-Close gesper…

### DIFF
--- a/public/css/room.css
+++ b/public/css/room.css
@@ -264,3 +264,9 @@
   cursor: not-allowed;
   pointer-events: none;
 }
+
+.multiplier-slider--room-guest {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}

--- a/public/script/room.ts
+++ b/public/script/room.ts
@@ -358,12 +358,14 @@ function setRoomActive(roomKey: string, host: boolean): void {
   if (!host) {
     spinLeftBtn.classList.add('spin__btn--room-guest');
     spinRightBtn.classList.add('spin__btn--room-guest');
+    multiplierSlider.classList.add('multiplier-slider--room-guest');
     resetBtn.disabled = true;
     resetBtn.style.setProperty('opacity', '0.4');
     resetBtn.style.setProperty('cursor', 'not-allowed');
   } else {
     spinLeftBtn.classList.remove('spin__btn--room-guest');
     spinRightBtn.classList.remove('spin__btn--room-guest');
+    multiplierSlider.classList.remove('multiplier-slider--room-guest');
     setResetOverride(() => { void handleRoomReset(false); });
     setWinnerModalCloseOverride(() => { void handleRoomReset(true); });
   }
@@ -394,6 +396,7 @@ function clearRoom(): void {
   if (roomInfo) roomInfo.classList.add('hidden');
   spinLeftBtn.classList.remove('spin__btn--room-guest', 'spin__btn--room-solo');
   spinRightBtn.classList.remove('spin__btn--room-guest', 'spin__btn--room-solo');
+  multiplierSlider.classList.remove('multiplier-slider--room-guest');
   resetBtn.disabled = false;
   resetBtn.style.removeProperty('opacity');
   resetBtn.style.removeProperty('cursor');
@@ -454,6 +457,9 @@ async function handleRoomReset(closeWinnerModal: boolean): Promise<void> {
 
 function handleWheelResetEvent(): void {
   resetWheelRotation();
+  if (activeRoomKey && !isHost) {
+    disableMultiplierSlider();
+  }
 }
 
 function handleWinnerModalCloseEvent(): void {
@@ -737,6 +743,10 @@ export function initRoomControls(): void {
 
 export function isMultiplayerActive(): boolean {
   return !!activeRoomKey;
+}
+
+export function isRoomHost(): boolean {
+  return isHost;
 }
 
 async function hasActiveSession(): Promise<boolean> {

--- a/public/script/wheel/winner.ts
+++ b/public/script/wheel/winner.ts
@@ -1,8 +1,9 @@
-import { isMultiplayerActive } from "../room";
+import { isMultiplayerActive, isRoomHost } from "../room";
 import { awardCoins } from "../api/spin-api";
 import { getNamesInWheelList, removeNameFromListByIndex } from "../names/names-in-wheel-list";
 import { stopDrumRoll } from "./sound";
 import { resetWheelRotation } from "./spin";
+import { disableMultiplierSlider } from "./multiplier";
 import { refreshCoinDisplay } from "../profile/profiles";
 import { showToast } from "../shared/toast";
 import { requiredElement } from "../shared/dom-helpers";
@@ -150,6 +151,9 @@ export function setWinnerModalCloseOverride(handler: (() => void) | null): void 
 function closeWinnerModalLocally(): void {
   hideWinnerModal();
   resetWheelRotation();
+  if (isMultiplayerActive() && !isRoomHost()) {
+    disableMultiplierSlider();
+  }
 }
 
 export function initWinnerModal(): void {


### PR DESCRIPTION
…rt halten

unlockSpinButtons() setzte den Slider unabhängig von der Rolle frei. Neue CSS-Klasse blockiert Maus/Touch dauerhaft, zusätzliche disableMultiplierSlider()-Aufrufe nach Reset/WinnerModal-Close schließen die verbleibende Tastatur-Lücke.
Closes #350