### PR TITLE
refactor(spin): Spin-Logik in spin-service gebündelt, parameterlose Zufallszahlgenerierung

### DIFF
--- a/server/src/services/room-service.ts
+++ b/server/src/services/room-service.ts
@@ -1,6 +1,5 @@
-import { randomBytes, randomUUID } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import { getProfileByUserId } from "../repositories/profile-repository";
-import { getSecureRandomNumber } from "../lib/random";
 import {
     insertRoom,
     getRoomByKey,
@@ -13,9 +12,9 @@ import {
     updateRoomSpin,
     updateRoomMultiplier,
     updateRoomReset,
-    insertSpinToken,
     type RoomPlayer,
 } from "../repositories/room-repository";
+import { generateSpin } from "./spin-service";
 import { AppError } from "../lib/errors";
 import type { CreateRoomResponseBody, JoinRoomResponseBody, SpinRandomResponseBody } from "shared";
 
@@ -89,12 +88,10 @@ export async function spinRoom(userId: string, roomKey: string, direction: strin
     if (!room) throw new AppError("Room not found", 404);
     if (room.host_id !== userId) throw new AppError("Only the host may spin", 403);
 
-    const ranNum = getSecureRandomNumber(0, 359);
+    const { ranNum, spinToken } = await generateSpin(userId);
     const spunAt = new Date().toISOString();
     await updateRoomSpin(roomKey, ranNum, spunAt, direction);
 
-    const token = randomUUID();
-    const spinToken = await insertSpinToken(token, userId);
     return { ranNum, spinToken };
 }
 

--- a/server/src/services/spin-service.ts
+++ b/server/src/services/spin-service.ts
@@ -10,11 +10,20 @@ import {
 import { insertSpinToken, findValidSpinToken, markSpinTokenUsed } from "../repositories/room-repository";
 import type { SpinRandomResponseBody, AwardCoinsResponseBody } from "shared";
 
-const MIN_ROTATION_DEGREE = 0;
-const MAX_ROTATION_DEGREE = 359;
+function getRandomWheelSpinNumber(): number {
+    return getSecureRandomNumber(0, 359);
+}
+
+function getRandomSpinnerCoins(): number {
+    return getSecureRandomNumber(1, 3);
+}
+
+function getRandomWinnerCoins(): number {
+    return getSecureRandomNumber(3, 6);
+}
 
 export async function generateSpin(userId: string): Promise<SpinRandomResponseBody> {
-    const ranNum = getSecureRandomNumber(MIN_ROTATION_DEGREE, MAX_ROTATION_DEGREE);
+    const ranNum = getRandomWheelSpinNumber();
     const spinToken = await insertSpinToken(randomUUID(), userId);
     return { ranNum, spinToken };
 }
@@ -27,7 +36,7 @@ export async function awardCoins(userId: string, spinToken: string, winnerName: 
 
     await markSpinTokenUsed(spinToken);
 
-    const spinnerCoins = getSecureRandomNumber(1, 3);
+    const spinnerCoins = getRandomSpinnerCoins();
     const spinnerProfile = await getProfileByUserId(userId);
     const spinnerName = spinnerProfile?.username ?? userId;
 
@@ -35,7 +44,7 @@ export async function awardCoins(userId: string, spinToken: string, winnerName: 
     const spinnerIsWinner = winnerUserId === userId;
 
     if (spinnerIsWinner) {
-        const winnerCoins = getSecureRandomNumber(3, 6);
+        const winnerCoins = getRandomWinnerCoins();
         await addCoins(userId, spinnerCoins + winnerCoins);
         console.log(`[coins] ${spinnerName} hat selbst gewonnen → +${spinnerCoins + winnerCoins} Coins`);
         return { spinnerCoins, winnerCoins, total: spinnerCoins + winnerCoins };
@@ -45,7 +54,7 @@ export async function awardCoins(userId: string, spinToken: string, winnerName: 
     console.log(`[coins] Spinner: ${spinnerName} → +${spinnerCoins} Coins`);
 
     if (winnerUserId) {
-        const winnerCoins = getSecureRandomNumber(3, 6);
+        const winnerCoins = getRandomWinnerCoins();
         await addCoins(winnerUserId, winnerCoins);
         console.log(`[coins] Winner: ${winnerName} → +${winnerCoins} Coins`);
         return { spinnerCoins, winnerCoins };


### PR DESCRIPTION
## Ticket 404  Dedupe Spin-Logik

- `spin-service.ts` enthält jetzt die alleinige Spin-Logik; `room-service.spinRoom()` ruft `generateSpin()` daraus auf statt Zufallszahl + Spin-Token selbst zu erzeugen
- Ungenutzte Imports in `room-service.ts` entfernt: `getSecureRandomNumber`, `randomUUID`, `insertSpinToken`
- `getSecureRandomNumber(min, max)` durch dedizierte, parameterlose Funktionen ersetzt (definiert dort, wo genutzt, in `spin-service.ts`):
  - `getRandomWheelSpinNumber()` (0–359)
  - `getRandomSpinnerCoins()` (1–3)
  - `getRandomWinnerCoins()` (3–6, ersetzt beide identischen Aufrufe in `awardCoins()`)
- `getSecureRandomNumber` in `lib/random.ts` bleibt als generische Primitive bestehen, bestehender Test bleibt gültig

Closes #404