### PR TITLE
ci(db): Migration-Repair für Version 24 ergänzt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
+      - name: Repair Migration History (Falsche Version 24 löschen)
+        run: npx supabase migration repair --status reverted 24 --linked
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
       - name: Run DB Migrations
         run: npx supabase db push --linked --include-all
         env:


### PR DESCRIPTION
Refs #409

# Beschreibung

Migration `24_unique_asset_name_category.sql` wurde gelöscht, obwohl sie remote schon angewendet war. `supabase db push` bricht deshalb ab.

# Fix

Repair-Schritt für Version 24 in `ci.yml` ergänzt (analog zu Version 12).
