### PR TITLE
feat(i18n): integrate internationalization for room messages and actions

### DIFF
--- a/public/script/multiplayer/game-mode-strategy.ts
+++ b/public/script/multiplayer/game-mode-strategy.ts
@@ -15,6 +15,7 @@ import { getNameValidationMessage } from "../names/name-input-validation";
 import { MAX_ITEMS } from "../names/names-in-wheel-list-state";
 import { validateName } from "../shared/validation";
 import { showToast } from "../shared/toast";
+import { t } from "../app/i18n";
 import { spinRoom, updateRoomNames, resetRoom } from "../api/room-api";
 import { activeRoomKey, activeRoomNamesInWheelList, getMissingPlayers } from "./room-state";
 
@@ -74,11 +75,11 @@ export class SoloModeStrategy implements GameModeStrategy {
   // versteckt, solange currentMode SoloModeStrategy ist. Nur wegen des
   // GameModeStrategy-Interfaces Pflicht, siehe GuestModeStrategy.addName().
   getLeaveConfirmMessage(): string {
-    return 'Raum wirklich verlassen?';
+    return t('room.leaveConfirmGuest');
   }
 
   getLeaveResultMessage(success: boolean): string {
-    return success ? 'Raum verlassen' : 'Raum konnte nicht verlassen werden';
+    return t(success ? 'room.left' : 'api.room.leaveFailed');
   }
 }
 
@@ -95,7 +96,7 @@ async function handleRoomReset(closeWinnerModal: boolean): Promise<void> {
     // vorzupreschen.
   } catch (error) {
     console.error('[ROOM] Reset fehlgeschlagen:', error);
-    showToast({ message: 'Reset fehlgeschlagen', type: 'error' });
+    showToast({ message: t('api.room.resetFailed'), type: 'error' });
   }
 }
 
@@ -116,7 +117,7 @@ export class HostModeStrategy implements GameModeStrategy {
     } catch (error) {
       console.error('[ROOM] Spin fehlgeschlagen:', error);
       applyGameModeLock();
-      showToast({ message: 'Spin fehlgeschlagen', type: 'error' });
+      showToast({ message: t('api.room.spinFailed'), type: 'error' });
     }
   }
 
@@ -141,7 +142,7 @@ export class HostModeStrategy implements GameModeStrategy {
 
     const existingNamesInWheelList = activeRoomNamesInWheelList ?? [];
     if (existingNamesInWheelList.length >= MAX_ITEMS) {
-      showToast({ message: `Maximal ${MAX_ITEMS} Einträge erlaubt.`, type: 'error' });
+      showToast({ message: t('names.maxItems', { max: MAX_ITEMS }), type: 'error' });
       return;
     }
 
@@ -164,7 +165,7 @@ export class HostModeStrategy implements GameModeStrategy {
     if (missingPlayers.length > 0) {
       const updatedNamesInWheelList = [...existingNamesInWheelList, ...missingPlayers];
       if (updatedNamesInWheelList.length > MAX_ITEMS) {
-        showToast({ message: `Maximal ${MAX_ITEMS} Einträge erlaubt.`, type: 'error' });
+        showToast({ message: t('names.maxItems', { max: MAX_ITEMS }), type: 'error' });
         return;
       }
       await updateRoomNamesIfActiveRoomKey(updatedNamesInWheelList);
@@ -185,13 +186,13 @@ export class HostModeStrategy implements GameModeStrategy {
 
   getLeaveConfirmMessage(guestCount: number): string {
     if (guestCount > 0) {
-      return `Du bist Host von ${guestCount} ${guestCount === 1 ? 'Mitspieler' : 'Mitspielern'}. Raum wirklich schließen?`;
+      return t('room.leaveConfirmGuests', { count: guestCount });
     }
-    return 'Raum wirklich schließen?';
+    return t('room.leaveConfirmHost');
   }
 
   getLeaveResultMessage(success: boolean): string {
-    return success ? 'Raum geschlossen' : 'Raum konnte nicht geschlossen werden';
+    return t(success ? 'room.closed' : 'api.room.closeFailed');
   }
 }
 
@@ -238,11 +239,11 @@ export class GuestModeStrategy implements GameModeStrategy {
   }
 
   getLeaveConfirmMessage(): string {
-    return 'Raum wirklich verlassen?';
+    return t('room.leaveConfirmGuest');
   }
 
   getLeaveResultMessage(success: boolean): string {
-    return success ? 'Raum verlassen' : 'Raum konnte nicht verlassen werden';
+    return t(success ? 'room.left' : 'api.room.leaveFailed');
   }
 }
 

--- a/public/script/multiplayer/room-buttons.ts
+++ b/public/script/multiplayer/room-buttons.ts
@@ -2,6 +2,7 @@ import { optionalElement } from "../shared/dom-helpers";
 import { addBtn, input } from "../names/names-in-wheel-list";
 import { isSpinning } from "../wheel/spin";
 import { showToast } from "../shared/toast";
+import { t } from "../app/i18n";
 import { activeRoomKey, activeRoomPlayers, roomKeyDisplay } from "./room-state";
 import { getCurrentMode } from "./game-mode-strategy";
 import { playersList, bulkAddToWheelBtn } from "./room-players-sidebar";
@@ -33,7 +34,7 @@ export function showSwitchRoomConfirm(message: string, action: () => Promise<voi
 // der erklärt, warum die Raum-Aktion gerade nicht ausgeführt werden darf.
 function isBlockedBySpinning(): boolean {
   if (!isSpinning()) return false;
-  showToast({ message: 'Bitte warte, bis das Rad aufgehört hat zu drehen', type: 'error' });
+  showToast({ message: t('room.waitForWheelStop'), type: 'error' });
   return true;
 }
 
@@ -66,7 +67,7 @@ export function initRoomButtons(): void {
   createRoomBtn?.addEventListener('click', () => {
     if (isBlockedBySpinning()) return;
     startRoomAction(
-      `Du bist noch in Raum ${activeRoomKey}. Raum verlassen und neuen Raum erstellen?`,
+      t('room.switchToNewRoom', { currentRoom: activeRoomKey }),
       executeCreateRoom,
     );
   });
@@ -76,7 +77,7 @@ export function initRoomButtons(): void {
     if (!roomKey) return;
     if (isBlockedBySpinning()) return;
     startRoomAction(
-      `Du bist noch in Raum ${activeRoomKey}. Raum verlassen und Raum ${roomKey} beitreten?`,
+      t('room.switchRoom', { currentRoom: activeRoomKey, targetRoom: roomKey }),
       () => executeJoinRoom(roomKey),
     );
   });
@@ -118,7 +119,7 @@ export function initRoomButtons(): void {
         btn.classList.remove('room__btn--copied');
         btn.innerHTML = '&#128203;';
       }, 1500);
-      showToast({ message: 'Code in die Zwischenablage kopiert', type: 'success' });
+      showToast({ message: t('room.copied'), type: 'success' });
     });
   });
 }

--- a/public/script/multiplayer/room-orchestration.ts
+++ b/public/script/multiplayer/room-orchestration.ts
@@ -9,6 +9,7 @@ import { getMultiplier, setMultiplierSlider, updateMultiplierDisplay, multiplier
 import { hideWinnerModal } from "../wheel/winner";
 import { initChat, destroyChat } from "./room-chat";
 import { showToast } from "../shared/toast";
+import { t } from "../app/i18n";
 import { createRoom, leaveRoom, joinRoom, setMultiplier } from '../api/room-api';
 import { subscribeToRoom, unsubscribeFromRoom } from "./room-realtime-sync";
 import {
@@ -110,7 +111,7 @@ function handleWinnerModalCloseEvent(): void {
 function onRoomClosed(): void {
   if (getCurrentMode().isHost()) return; // host handles its own leave flow
   clearRoom();
-  showToast({ message: 'Der Host hat den Raum geschlossen', type: 'info' });
+  showToast({ message: t('room.hostClosed'), type: 'info' });
 }
 
 function setNamesFromRoom(names: string[]): void {
@@ -169,10 +170,10 @@ export async function executeCreateRoom(): Promise<void> {
       void setMultiplier(activeRoomKey, getMultiplier());
     };
     multiplierSlider?.addEventListener('input', multiplierSyncListener);
-    showToast({ message: `Raum erstellt: ${roomKey}`, type: 'success' });
+    showToast({ message: t('room.created', { roomKey }), type: 'success' });
   } catch (error) {
     console.error('[ROOM] Erstellen fehlgeschlagen:', error);
-    showToast({ message: 'Raum konnte nicht erstellt werden', type: 'error' });
+    showToast({ message: t('api.room.createFailed'), type: 'error' });
   }
 }
 
@@ -189,9 +190,9 @@ export async function executeJoinRoom(roomKey: string): Promise<void> {
     setMultiplierSlider(multiplier);
     updateMultiplierDisplay();
     finishRoomSetup(roomKey);
-    showToast({ message: `Raum beigetreten: ${roomKey}`, type: 'success' });
+    showToast({ message: t('room.joined', { roomKey }), type: 'success' });
   } catch (error) {
     console.error('[ROOM] Beitreten fehlgeschlagen:', error);
-    showToast({ message: 'Raum nicht gefunden oder Fehler beim Beitreten', type: 'error' });
+    showToast({ message: t('api.room.joinFailed'), type: 'error' });
   }
 }

--- a/public/script/multiplayer/room-players-sidebar.ts
+++ b/public/script/multiplayer/room-players-sidebar.ts
@@ -3,6 +3,7 @@ import { getNamesInWheelList, addBtn, input } from "../names/names-in-wheel-list
 import { applyDisabledStyle } from "../wheel/spin";
 import { activeRoomHostName, activeRoomNamesInWheelList, getMissingPlayers } from "./room-state";
 import { getCurrentMode } from "./game-mode-strategy";
+import { t } from "../app/i18n";
 
 export const playersList = optionalElement<HTMLUListElement>("room-players-list");
 
@@ -22,7 +23,7 @@ export function renderPlayersSidebar(players: string[]): void {
 
     if (name === activeRoomHostName) {
       const hostTag = document.createElement('span');
-      hostTag.textContent = 'Host';
+      hostTag.textContent = t('room.host');
       hostTag.className = 'room__host-tag';
       playerEntry.appendChild(hostTag);
     }
@@ -34,7 +35,10 @@ export function renderPlayersSidebar(players: string[]): void {
       const isPlayerInWheelList = (activeRoomNamesInWheelList ?? []).includes(name);
       togglePlayerInWheelListBtn.textContent = isPlayerInWheelList ? '−' : '+';
       if (isPlayerInWheelList) togglePlayerInWheelListBtn.classList.add('room__player-toggle-btn--added');
-      togglePlayerInWheelListBtn.title = isPlayerInWheelList ? `Vom Rad entfernen: ${name}` : `Zu Rad hinzufügen: ${name}`;
+      togglePlayerInWheelListBtn.title = t(
+        isPlayerInWheelList ? 'room.removeFromWheel' : 'room.addToWheel',
+        { name },
+      );
 
       togglePlayerInWheelListBtn.addEventListener('click', async () => {
         togglePlayerInWheelListBtn.disabled = true;
@@ -88,10 +92,10 @@ export function updateBulkButtonState(players: string[]): void {
   if (!bulkAddToWheelBtn) return;
   const anyMissing = getMissingPlayers(players, activeRoomNamesInWheelList ?? []).length > 0;
   if (anyMissing) {
-    bulkAddToWheelBtn.textContent = 'Alle zum Rad hinzufügen';
+    bulkAddToWheelBtn.textContent = t('room.bulkAdd');
     bulkAddToWheelBtn.classList.remove('room__btn--remove');
   } else {
-    bulkAddToWheelBtn.textContent = 'Alle vom Rad entfernen';
+    bulkAddToWheelBtn.textContent = t('room.bulkRemove');
     bulkAddToWheelBtn.classList.add('room__btn--remove');
   }
 }

--- a/public/script/profile/profiles.ts
+++ b/public/script/profile/profiles.ts
@@ -77,7 +77,7 @@ function bindProfileActions(): void {
       window.location.href = "/login.html";
       return;
     }
-    showSwitchRoomConfirm("room.logoutConfirm", async () => {
+    showSwitchRoomConfirm(t("room.logoutConfirm"), async () => {
       if (activeRoomKey) await executeLeaveRoom();
       await supabaseClient.auth.signOut();
       notifyAccountChanged();


### PR DESCRIPTION
Überarbeitung der i18n-Implementierung im Multiplayerbereich. Hardcodierte deutsche UI-Texte, Toasts, Fehlermeldungen und Bestätigungsdialoge wurden durch Übersetzungsschlüssel ersetzt. Dynamische Texte wie „Alle zum Rad hinzufügen“, Raum-Erstellungs-/Schließ-Toasts sowie Leave-/Logout-Bestätigungen reagieren nun korrekt auf die gewählte Sprache. 