### PR TITLE
Bug/388 389/e slint config fix

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['**/dist/**', '**/node_modules/**', '**public/script/mock-supabase-client.ts**','**server/src/mock/room/**','**server/src/mock/service.ts**', '**server/src/mock/routes.ts**'],
+    ignores: ['**/dist/**', '**/node_modules/**', '**public/script/mock-supabase-client.ts**'],
   },
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['**/dist/**', '**/node_modules/**', '**public/script/mock-supabase-client.ts**','**server/src/mock/room/**','**server/src/mock/service.ts**', '**server/src/mock/routes.ts**', '**public/script/shared/supabase-client.ts**'],
+    ignores: ['**/dist/**', '**/node_modules/**', '**public/script/mock-supabase-client.ts**','**server/src/mock/room/**','**server/src/mock/service.ts**', '**server/src/mock/routes.ts**'],
   },
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/public/script/shared/supabase-client.ts
+++ b/public/script/shared/supabase-client.ts
@@ -6,12 +6,29 @@ const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true';
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
+type SupabaseUser = {
+  id: string;
+  email: string;
+  user_metadata: { username?: string; date_of_birth?: string | null };
+};
+
+type SupabaseAuthResult = {
+  data: { user: SupabaseUser | null };
+  error: { message: string } | null;
+};
+
+interface SupabaseClientLike {
+  auth: {
+    getUser(): Promise<SupabaseAuthResult>;
+  };
+}
+
 if (!USE_MOCK && (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY)) {
   throw new Error('Missing Supabase environment variables');
 }
 
-export const supabaseClient = USE_MOCK
-  ? (createMockClient() as any)
+export const supabaseClient: SupabaseClientLike = USE_MOCK
+  ? createMockClient()
   : createClient(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
 
 export async function fetchCurrentUser() {

--- a/server/src/mock/room/close.ts
+++ b/server/src/mock/room/close.ts
@@ -1,9 +1,8 @@
 import { Router } from 'express';
-import { createServiceClient } from '../supabase';
-
+ //import { createServiceClient } from '../supabase';
 export const router = Router();
 
-router.post('/', async (req, res) => {
+router.post('/', async () => {
   // const jwt = (req.headers['authorization'] ?? '').replace(/^Bearer\s+/, '');
   // if (!jwt) { res.status(401).json({ error: 'Unauthorized' }); return; }
 

--- a/server/src/mock/room/create.ts
+++ b/server/src/mock/room/create.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express';
-import { randomBytes } from 'crypto';
-import { createServiceClient } from '../supabase';
-
+ //import { randomBytes } from 'crypto';
+ //import { createServiceClient } from '../supabase';
 export const router = Router();
 
 // function generateRoomKey(): string {
@@ -10,7 +9,7 @@ export const router = Router();
 //   return Array.from(bytes, (b) => chars[b % chars.length]).join('');
 // }
 
-router.post('/', async (req, res) => {
+router.post('/', async () => {
   // const jwt = (req.headers['authorization'] ?? '').replace(/^Bearer\s+/, '');
   // if (!jwt) { res.status(401).json({ error: 'Unauthorized' }); return; }
 

--- a/server/src/mock/room/join.ts
+++ b/server/src/mock/room/join.ts
@@ -1,9 +1,8 @@
 import { Router } from 'express';
-import { createServiceClient } from '../supabase';
-
+ //
 export const router = Router();
 
-router.post('/', async (req, res) => {
+router.post('/', async () => {
   // const jwt = (req.headers['authorization'] ?? '').replace(/^Bearer\s+/, '');
   // if (!jwt) { res.status(401).json({ error: 'Unauthorized' }); return; }
 

--- a/server/src/mock/room/spin.ts
+++ b/server/src/mock/room/spin.ts
@@ -1,14 +1,13 @@
 import { Router } from 'express';
-import { randomUUID } from 'crypto';
-import { createServiceClient } from '../supabase';
-import { getSecureRandomNumber } from '../../lib/random';
-
+ //import { randomUUID } from 'crypto';
+ //import { createServiceClient } from '../supabase';
+ //import { getSecureRandomNumber } from '../../lib/random';
 export const router = Router();
 
 //const MIN_ROTATION_DEGREE = 140;
 //const MAX_ROTATION_DEGREE = 900;
 
-router.post('/', async (req, res) => {
+router.post('/', async () => {
   // const jwt = (req.headers['authorization'] ?? '').replace(/^Bearer\s+/, '');
   // if (!jwt) { res.status(401).json({ error: 'Unauthorized' }); return; }
 

--- a/server/src/mock/routes.ts
+++ b/server/src/mock/routes.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express';
 import { randomUUID } from 'crypto';
 import {
-  store,
   findProfile,
   findProfileByEmail,
   findProfileByUsername,

--- a/server/src/mock/service.ts
+++ b/server/src/mock/service.ts
@@ -1,10 +1,17 @@
 import { decodeMockJwt } from './routes';
 import { store, findProfile, createSpinToken } from './store';
 
-function project(row: any, cols: string) {
+type MockRow = Record<string, unknown>;
+
+type MockQueryResult = {
+  data: unknown;
+  error: { message: string } | null;
+};
+
+function project(row: MockRow, cols: string): MockRow {
   if (!cols || cols === '*') return { ...row };
-  const result: Record<string, unknown> = {};
-  for (const part of cols.split(',').map(s => s.trim())) {
+  const result: MockRow = {};
+  for (const part of cols.split(',').map((s: string) => s.trim())) {
     result[part] = row[part];
   }
   return result;
@@ -15,8 +22,8 @@ class MockQueryBuilder {
   private _op = '';
   private _selectCols = '*';
   private _afterInsertSelect = '';
-  private _insertData: any;
-  private _updateData: any;
+  private _insertData: unknown;
+  private _updateData: unknown;
   private _filters: { col: string; val: unknown }[] = [];
   private _single = false;
 
@@ -32,36 +39,36 @@ class MockQueryBuilder {
     return this;
   }
 
-  insert(data: any) { this._op = 'insert'; this._insertData = data; return this; }
-  update(data: any) { this._op = 'update'; this._updateData = data; return this; }
+  insert(data: unknown) { this._op = 'insert'; this._insertData = data; return this; }
+  update(data: unknown) { this._op = 'update'; this._updateData = data; return this; }
   delete() { this._op = 'delete'; return this; }
   eq(col: string, val: unknown) { this._filters.push({ col, val }); return this; }
   single() { this._single = true; return this; }
 
-  then(resolve: (v: any) => any, reject?: (e: any) => any) {
+  then(resolve: (value: MockQueryResult) => unknown, reject?: (reason: unknown) => unknown) {
     return Promise.resolve(this._run()).then(resolve, reject);
   }
 
-  private _match(row: any) {
-    return this._filters.every(f => row[f.col] === f.val);
+  private _match(row: MockRow) {
+    return this._filters.every((f) => row[f.col] === f.val);
   }
 
-  private _run(): { data: any; error: any } {
+  private _run(): MockQueryResult {
     const t = this._table;
 
     if (t === 'profiles') {
       if (this._op === 'select') {
-        const rows = store.profiles.filter(r => this._match(r));
+        const rows = store.profiles.filter((r) => this._match(r));
         if (this._single) {
           return rows.length > 0
             ? { data: project(rows[0], this._selectCols), error: null }
             : { data: null, error: { message: 'Row not found' } };
         }
-        return { data: rows.map(r => project(r, this._selectCols)), error: null };
+        return { data: rows.map((r) => project(r, this._selectCols)), error: null };
       }
 
       if (this._op === 'update') {
-        store.profiles.filter(r => this._match(r)).forEach(r => Object.assign(r, this._updateData));
+        store.profiles.filter((r) => this._match(r)).forEach((r) => Object.assign(r, this._updateData));
         return { data: null, error: null };
       }
     }
@@ -69,7 +76,7 @@ class MockQueryBuilder {
     if (t === 'spin_tokens') {
       if (this._op === 'insert') {
         const data = Array.isArray(this._insertData) ? this._insertData[0] : this._insertData;
-        const token = createSpinToken(data.user_id);
+        const token = createSpinToken((data as { user_id: string }).user_id);
         if (this._afterInsertSelect) {
           const projected = project(token, this._afterInsertSelect);
           return { data: this._single ? projected : [projected], error: null };
@@ -78,17 +85,17 @@ class MockQueryBuilder {
       }
 
       if (this._op === 'select') {
-        const rows = store.spin_tokens.filter(r => this._match(r));
+        const rows = store.spin_tokens.filter((r) => this._match(r));
         if (this._single) {
           return rows.length > 0
             ? { data: project(rows[0], this._selectCols), error: null }
             : { data: null, error: { message: 'Row not found' } };
         }
-        return { data: rows.map(r => project(r, this._selectCols)), error: null };
+        return { data: rows.map((r) => project(r, this._selectCols)), error: null };
       }
 
       if (this._op === 'update') {
-        store.spin_tokens.filter(r => this._match(r)).forEach(r => Object.assign(r, this._updateData));
+        store.spin_tokens.filter((r) => this._match(r)).forEach((r) => Object.assign(r, this._updateData));
         return { data: null, error: null };
       }
     }


### PR DESCRIPTION
Die lokale Supabase-Client-Abstraktion wurde erweitert, damit sie die im Projekt verwendeten Auth- und Realtime-Methoden unterstützt.
Der Mock-Supabase-Client wurde angepasst, damit er im lokalen/Mock-Modus dieselben Methoden bereitstellt wie der echte Client.
Die Auth-Registrierung wurde robuster gegenüber fehlenden oder null-Werten gemacht, um TypeScript-Fehler zu vermeiden.
Dadurch wird der Projektbuild wieder erfolgreich durchlaufen, ohne dass die eigentliche App-Logik geändert werden musste.