### PR TITLE
Der Remove-Button im Winner-Modal ist nun für Hosts auch im Multiplay…

### DIFF
--- a/public/script/multiplayer/game-mode-strategy.ts
+++ b/public/script/multiplayer/game-mode-strategy.ts
@@ -8,7 +8,7 @@ import { multiplierSlider } from "../wheel/multiplier";
 import { hideWinnerModal } from "../wheel/winner";
 import {
   addNameToList, getNamesInWheelList,
-  addBtn, input, getRemoveBtn,
+  addBtn, input, getRemoveBtn, removeNameFromListByIndex,
 } from "../names/names-in-wheel-list";
 import { getNameValidationMessage } from "../names/name-input-validation";
 import { MAX_ITEMS } from "../names/names-in-wheel-list-state";
@@ -25,6 +25,7 @@ export interface GameModeStrategy {
   getRoleLockedElements(): SpinElement[];
   addNameToWheel(rawName: string): Promise<void>;
   removeNameFromWheel(index: number): Promise<void>;
+  removeWinnerFromWheel(index: number): Promise<void>;
   toggleAllPlayersInWheel(players: string[]): Promise<void>;
   canManagePlayers(): boolean;
   isHost(): boolean;
@@ -56,6 +57,12 @@ export class SoloModeStrategy implements GameModeStrategy {
 
   async removeNameFromWheel(): Promise<void> {
     // no-op — lokales Entfernen läuft direkt über die Namensliste, nicht über den Raum-Callback
+  }
+
+  async removeWinnerFromWheel(index: number): Promise<void> {
+    removeNameFromListByIndex(index);
+    hideWinnerModal();
+    resetWheelRotation();
   }
 
   async toggleAllPlayersInWheel(): Promise<void> {
@@ -159,6 +166,11 @@ export class HostModeStrategy implements GameModeStrategy {
     await updateRoomNamesIfActiveRoomKey(updatedNamesInWheelList);
   }
 
+  async removeWinnerFromWheel(index: number): Promise<void> {
+    await this.removeNameFromWheel(index);
+    await handleRoomReset(true);
+  }
+
   async toggleAllPlayersInWheel(players: string[]): Promise<void> {
     const existingNamesInWheelList = activeRoomNamesInWheelList ?? [];
     const missingPlayers = getMissingPlayers(players, existingNamesInWheelList);
@@ -225,6 +237,10 @@ export class GuestModeStrategy implements GameModeStrategy {
 
   async removeNameFromWheel(): Promise<void> {
     // no-op — nur der Host verwaltet die Namensliste
+  }
+
+  async removeWinnerFromWheel(): Promise<void> {
+    // no-op — Gäste dürfen Gewinner nicht vom gemeinsamen Rad entfernen
   }
 
   async toggleAllPlayersInWheel(): Promise<void> {

--- a/public/script/wheel/winner.ts
+++ b/public/script/wheel/winner.ts
@@ -1,9 +1,8 @@
 import { isMultiplayerActive } from "../multiplayer/room-state";
 import { getCurrentMode } from "../multiplayer/game-mode-strategy";
 import { awardCoins } from "../api/spin-api";
-import { getNamesInWheelList, removeNameFromListByIndex } from "../names/names-in-wheel-list";
+import { getNamesInWheelList } from "../names/names-in-wheel-list";
 import { stopDrumRoll } from "./sound";
-import { resetWheelRotation } from "./spin";
 import { refreshCoinDisplay } from "../profile/profiles";
 import { showToast } from "../shared/toast";
 import { requiredElement } from "../shared/dom-helpers";
@@ -28,11 +27,8 @@ export function displayWinnerModal(winnerName: string): void {
   winnerText.textContent = `${winnerName}`;
   winnerModal.classList.remove("hidden");
 
-  if (isMultiplayerActive()) {
-    removeWinnerBtn.classList.add("hidden");
-  } else {
-    removeWinnerBtn.classList.remove("hidden");
-  }
+  const canRemoveWinner = !isMultiplayerActive() || getCurrentMode().isHost();
+  removeWinnerBtn.classList.toggle("hidden", !canRemoveWinner);
 }
 
 export function hideWinnerModal(): void {
@@ -116,15 +112,15 @@ export function announceWinner(spinToken: string, winnerName: string): void {
     });
 }
 
-function removeWinner(): void {
+async function removeWinner(): Promise<void> {
+  if (isMultiplayerActive() && !getCurrentMode().isHost()) return;
   if (!lastWinnerName) return;
   const removedName = lastWinnerName;
   const names = getNamesInWheelList();
   const index = names.indexOf(removedName);
 
   if (index < 0) {
-    hideWinnerModal();
-    resetWheelRotation();
+    getCurrentMode().onWinnerModalClose();
     return;
   }
 
@@ -135,9 +131,12 @@ function removeWinner(): void {
     });
   }
 
-  removeNameFromListByIndex(index);
-  hideWinnerModal();
-  resetWheelRotation();
+  try {
+    await getCurrentMode().removeWinnerFromWheel(index);
+  } catch (error) {
+    console.error("[WINNER] Gewinner konnte nicht vom Rad entfernt werden:", error);
+    showToast({ message: t("api.room.updateWheelFailed"), type: "error" });
+  }
 }
 
 const closeWinnerModalBtn = requiredElement<HTMLButtonElement>("winner-modal-close-btn");
@@ -149,5 +148,12 @@ export function initWinnerModal(): void {
     getCurrentMode().onWinnerModalClose();
   });
 
-  removeWinnerBtn.addEventListener("click", removeWinner);
+  removeWinnerBtn.addEventListener("click", async () => {
+    removeWinnerBtn.disabled = true;
+    try {
+      await removeWinner();
+    } finally {
+      removeWinnerBtn.disabled = false;
+    }
+  });
 }


### PR DESCRIPTION
…er verfügbar. Gäste sehen den Button nicht und können den Vorgang nicht auslösen. Das Entfernen aktualisiert die gemeinsame Raum-Namensliste und schließt das Winner-Modal synchron für alle Spieler.