### PR TITLE
Feature/232/profile logik zentralisieren

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -42,9 +42,7 @@
         "user": {
             "loadCoinsFailed": "Coins konnten nicht geladen werden.",
             "loadProfileFailed": "Das Profil konnte nicht geladen werden.",
-            "addCoinsFailed": "Coins konnten nicht aktualisiert werden.",
-            "defaultAssetsFailed": "Standard-Assets konnten nicht eingerichtet werden.",
-            "subtractCoinsFailed": "Coins konnten nicht abgezogen werden."
+            "defaultAssetsFailed": "Standard-Assets konnten nicht eingerichtet werden."
         },
         "spin": {
             "randomFailed": "Die Drehung konnte nicht gestartet werden.",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -42,9 +42,7 @@
         "user": {
             "loadCoinsFailed": "Could not load coins.",
             "loadProfileFailed": "Could not load profile.",
-            "addCoinsFailed": "Could not update coins.",
-            "defaultAssetsFailed": "Could not initialize default assets.",
-            "subtractCoinsFailed": "Could not subtract coins."
+            "defaultAssetsFailed": "Could not initialize default assets."
         },
         "spin": {
             "randomFailed": "Could not start the spin.",

--- a/public/script/app/main.ts
+++ b/public/script/app/main.ts
@@ -1,6 +1,6 @@
 import { profileName } from "../profile/profiles";
 import { applyActiveAssets } from "../shared/asset-selection";
-import { ensureDefaultAssets } from "../api/user-api";
+import { ensureDefaultAssets } from "../profile/user-api";
 import { initInventory } from "../inventory/inventory";
 import { initNamesInWheelList } from "../names/names-in-wheel-list";
 import { initShareFeature } from "../names/share-names-in-wheel-list";

--- a/public/script/app/main.ts
+++ b/public/script/app/main.ts
@@ -1,10 +1,9 @@
-import { profileName } from "../profile/profiles";
+import { profileData } from "../profile/profile-data";
 import { applyActiveAssets } from "../shared/asset-selection";
-import { ensureDefaultAssets } from "../profile/user-api";
 import { initInventory } from "../inventory/inventory";
 import { initNamesInWheelList } from "../names/names-in-wheel-list";
 import { initShareFeature } from "../names/share-names-in-wheel-list";
-import { initProfileUI } from "../profile/profiles";
+import { initProfileUI } from "../profile/profile-ui";
 import { initWheelControls } from "../wheel/spin";
 import { initMultiplierButton } from "../wheel/multiplier";
 import { initVolumeSlider } from "../wheel/volume";
@@ -89,8 +88,8 @@ async function initApp(): Promise<void> {
   initShareFeature();
   initAuthChannelListener();
   await initProfileUI();
-  setMyUsername(profileName?.textContent?.trim() || t("generic.anonymous"));
-  await ensureDefaultAssets();
+  setMyUsername(profileData.getState().username?.trim() || t("generic.anonymous"));
+  await profileData.ensureDefaultAssets();
   await applyActiveAssets();
   initInventory();
   initShop();

--- a/public/script/profile/profile-data.ts
+++ b/public/script/profile/profile-data.ts
@@ -1,8 +1,8 @@
 import { supabaseClient } from "../shared/supabase-client";
 import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
-import { getUserProfile, getUserCoins } from "./user-api";
+import { getUserProfile, getUserCoins, ensureDefaultAssets as ensureDefaultAssetsApi } from "./user-api";
 
-interface UserProfileState {
+export interface UserProfileState {
     username: string | null;
     coins: number;
     isAuthenticated: boolean;
@@ -40,12 +40,19 @@ export class ProfileData {
         this.setState({ ...this.currentState, coins });
     }
 
-    // Das UI holt sich die Daten nur über eine Leseschnittstelle
+    public async signOut(): Promise<void> {
+        await supabaseClient.auth.signOut();
+        this.setState({ username: null, coins: 0, isAuthenticated: false });
+    }
+
+    public async ensureDefaultAssets(): Promise<void> {
+        await ensureDefaultAssetsApi();
+    }
+
     public getState(): UserProfileState {
         return { ...this.currentState };
     }
 
-    // UI-Komponenten registrieren sich hier, um über Änderungen informiert zu werden.
     public subscribe(listener: ProfileDataListener): () => void {
         this.listeners.add(listener);
         return () => this.listeners.delete(listener);
@@ -70,3 +77,5 @@ export class ProfileData {
             .subscribe();
     }
 }
+
+export const profileData = new ProfileData();

--- a/public/script/profile/profile-data.ts
+++ b/public/script/profile/profile-data.ts
@@ -8,38 +8,52 @@ interface UserProfileState {
     isAuthenticated: boolean;
 }
 
+type ProfileDataListener = (state: UserProfileState) => void;
+
 export class ProfileData {
     private currentState: UserProfileState = {
         username: null,
         coins: 0,
         isAuthenticated: false,
     };
+    private listeners = new Set<ProfileDataListener>();
 
     public async initializeProfile(): Promise<void> {
         const { data: { session }, error } = await supabaseClient.auth.getSession();
         if (error || !session?.user) {
-            this.currentState = { username: null, coins: 0, isAuthenticated: false };
+            this.setState({ username: null, coins: 0, isAuthenticated: false });
             return;
         }
 
         const profile = await getUserProfile();
-        this.currentState = {
+        this.setState({
             username: profile?.username ?? null,
             coins: profile?.coins ?? 0,
             isAuthenticated: true,
-        };
+        });
 
         this.subscribeToCoinUpdates(session.user.id);
     }
 
     public async refreshCoins(): Promise<void> {
         const coins = await getUserCoins();
-        this.currentState = { ...this.currentState, coins };
+        this.setState({ ...this.currentState, coins });
     }
 
     // Das UI holt sich die Daten nur über eine Leseschnittstelle
     public getState(): UserProfileState {
         return { ...this.currentState };
+    }
+
+    // UI-Komponenten registrieren sich hier, um über Änderungen informiert zu werden.
+    public subscribe(listener: ProfileDataListener): () => void {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    }
+
+    private setState(newState: UserProfileState): void {
+        this.currentState = newState;
+        this.listeners.forEach((listener) => listener(this.getState()));
     }
 
     private subscribeToCoinUpdates(userId: string): void {
@@ -50,7 +64,7 @@ export class ProfileData {
                 { event: "UPDATE", schema: "public", table: "profiles", filter: `id=eq.${userId}` },
                 (payload: RealtimePostgresChangesPayload<{ coins?: number }>) => {
                     const coins = (payload.new as { coins?: number })?.coins ?? 0;
-                    this.currentState = { ...this.currentState, coins };
+                    this.setState({ ...this.currentState, coins });
                 }
             )
             .subscribe();

--- a/public/script/profile/profile-data.ts
+++ b/public/script/profile/profile-data.ts
@@ -1,0 +1,58 @@
+import { supabaseClient } from "../shared/supabase-client";
+import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+import { getUserProfile, getUserCoins } from "./user-api";
+
+interface UserProfileState {
+    username: string | null;
+    coins: number;
+    isAuthenticated: boolean;
+}
+
+export class ProfileData {
+    private currentState: UserProfileState = {
+        username: null,
+        coins: 0,
+        isAuthenticated: false,
+    };
+
+    public async initializeProfile(): Promise<void> {
+        const { data: { session }, error } = await supabaseClient.auth.getSession();
+        if (error || !session?.user) {
+            this.currentState = { username: null, coins: 0, isAuthenticated: false };
+            return;
+        }
+
+        const profile = await getUserProfile();
+        this.currentState = {
+            username: profile?.username ?? null,
+            coins: profile?.coins ?? 0,
+            isAuthenticated: true,
+        };
+
+        this.subscribeToCoinUpdates(session.user.id);
+    }
+
+    public async refreshCoins(): Promise<void> {
+        const coins = await getUserCoins();
+        this.currentState = { ...this.currentState, coins };
+    }
+
+    // Das UI holt sich die Daten nur über eine Leseschnittstelle
+    public getState(): UserProfileState {
+        return { ...this.currentState };
+    }
+
+    private subscribeToCoinUpdates(userId: string): void {
+        supabaseClient
+            .channel("coin-updates")
+            .on(
+                "postgres_changes",
+                { event: "UPDATE", schema: "public", table: "profiles", filter: `id=eq.${userId}` },
+                (payload: RealtimePostgresChangesPayload<{ coins?: number }>) => {
+                    const coins = (payload.new as { coins?: number })?.coins ?? 0;
+                    this.currentState = { ...this.currentState, coins };
+                }
+            )
+            .subscribe();
+    }
+}

--- a/public/script/profile/profile-ui.ts
+++ b/public/script/profile/profile-ui.ts
@@ -1,34 +1,24 @@
-import { supabaseClient } from "../shared/supabase-client";
 import { optionalElement } from "../shared/dom-helpers";
-import type { Session, RealtimePostgresChangesPayload } from "@supabase/supabase-js";
 import { namesInWheelListState, MAX_ITEMS } from "../names/names-in-wheel-list-state";
 import { isNameEditingLocked } from "../names/names-in-wheel-list";
 import { isSpinning } from "../wheel/spin";
 import { showToast } from "../shared/toast";
-import { getUserCoins, getUserProfile as fetchUserProfileFromApi } from "./user-api";
 import { notifyAccountChanged } from "../shared/auth-channel";
 import { activeRoomKey } from "../multiplayer/room-state";
 import { executeLeaveRoom } from "../multiplayer/room-orchestration";
 import { showSwitchRoomConfirm } from "../multiplayer/room-buttons";
 import { formatNumber } from "../app/format";
 import { t } from "../app/i18n";
-
+import { profileData, type UserProfileState } from "./profile-data";
 
 export const profileName = optionalElement<HTMLSpanElement>("user-profile-name");
 export const authButton = optionalElement<HTMLButtonElement>("auth-button");
 export const coinDisplay = optionalElement<HTMLSpanElement>("user-coin-display");
-let currentProfile: ProfileData | null = null;
-let initialized = false;
 
-async function fetchCurrentSession(): Promise<Session | null> {
-  const { data: { session }, error } = await supabaseClient.auth.getSession();
-  if (error || !session?.user) return null;
-  return session;
-}
+let initialized = false;
 
 function applyUnauthenticatedState(): void {
   if (!profileName || !authButton) return;
-  currentProfile = null;
   profileName.textContent = t("profile.notLoggedIn");
   authButton.textContent = t("profile.login");
 }
@@ -39,31 +29,28 @@ function applyCoinDisplay(coins: number): void {
   coinDisplay.style.display = "inline";
 }
 
-interface ProfileData {
-  username: string;
-  coins: number;
-}
-
-function applyAuthenticatedState(profile: ProfileData | null): void {
+function applyAuthenticatedState(state: UserProfileState): void {
   if (!profileName || !authButton) return;
-  currentProfile = profile;
-  const username = profile?.username ?? t("profile.loggedIn");
-  profileName.textContent = username;
-
-  if (profile) {
-    applyCoinDisplay(profile.coins ?? 0);
-  }
+  profileName.textContent = state.username ?? t("profile.loggedIn");
+  applyCoinDisplay(state.coins);
 
   profileName.classList.add("user-profile-name--clickable");
   profileName.title = t("profile.clickToAdd");
 
   authButton.textContent = t("profile.logout");
+}
 
+function render(state: UserProfileState): void {
+  if (!state.isAuthenticated) {
+    applyUnauthenticatedState();
+    return;
+  }
+  applyAuthenticatedState(state);
 }
 
 function bindProfileActions(): void {
   profileName?.addEventListener("click", () => {
-    const username = currentProfile?.username;
+    const username = profileData.getState().username;
     if (!username || isNameEditingLocked() || isSpinning()) return;
     if (!namesInWheelListState.addNameToWheelList(username)) {
       showToast({ message: t("profile.maxItems", { max: MAX_ITEMS }), type: "error" });
@@ -73,43 +60,17 @@ function bindProfileActions(): void {
   });
 
   authButton?.addEventListener("click", () => {
-    if (!currentProfile) {
+    if (!profileData.getState().isAuthenticated) {
       window.location.href = "/login.html";
       return;
     }
     showSwitchRoomConfirm(t("room.logoutConfirm"), async () => {
       if (activeRoomKey) await executeLeaveRoom();
-      await supabaseClient.auth.signOut();
+      await profileData.signOut();
       notifyAccountChanged();
       window.location.href = "/login.html";
     });
   });
-}
-
-function subscribeToCoinUpdates(userId: string): void {
-  if (!coinDisplay) return;
-
-  supabaseClient
-    .channel("coin-updates")
-    .on(
-      "postgres_changes",
-      { event: "UPDATE", schema: "public", table: "profiles", filter: `id=eq.${userId}` },
-      (payload: RealtimePostgresChangesPayload<{ coins?: number }>) => {
-        const coins = (payload.new as { coins?: number })?.coins ?? 0;
-        applyCoinDisplay(coins);
-      }
-    )
-    .subscribe();
-}
-
-export async function refreshCoinDisplay(): Promise<void> {
-  if (!coinDisplay) return;
-
-  const { data: { session } } = await supabaseClient.auth.getSession();
-  if (!session) return;
-
-  const coins = await getUserCoins();
-  applyCoinDisplay(coins);
 }
 
 export async function initProfileUI(): Promise<void> {
@@ -118,19 +79,16 @@ export async function initProfileUI(): Promise<void> {
   if (!initialized) {
     initialized = true;
     bindProfileActions();
-    window.addEventListener("app:language-changed", () => {
-      if (currentProfile) applyAuthenticatedState(currentProfile);
-      else applyUnauthenticatedState();
-    });
+    profileData.subscribe(render);
+    window.addEventListener("app:language-changed", () => render(profileData.getState()));
   }
 
-  const session = await fetchCurrentSession();
-  if (!session) {
-    applyUnauthenticatedState();
-    return;
-  }
+  await profileData.initializeProfile();
+  render(profileData.getState());
+}
 
-  const profile = await fetchUserProfileFromApi();
-  applyAuthenticatedState(profile);
-  subscribeToCoinUpdates(session.user.id);
+export async function refreshCoinDisplay(): Promise<void> {
+  if (!coinDisplay) return;
+  if (!profileData.getState().isAuthenticated) return;
+  await profileData.refreshCoins();
 }

--- a/public/script/profile/profiles.ts
+++ b/public/script/profile/profiles.ts
@@ -5,7 +5,7 @@ import { namesInWheelListState, MAX_ITEMS } from "../names/names-in-wheel-list-s
 import { isNameEditingLocked } from "../names/names-in-wheel-list";
 import { isSpinning } from "../wheel/spin";
 import { showToast } from "../shared/toast";
-import { getUserCoins, getUserProfile as fetchUserProfileFromApi } from "../api/user-api";
+import { getUserCoins, getUserProfile as fetchUserProfileFromApi } from "./user-api";
 import { notifyAccountChanged } from "../shared/auth-channel";
 import { activeRoomKey } from "../multiplayer/room-state";
 import { executeLeaveRoom } from "../multiplayer/room-orchestration";

--- a/public/script/profile/user-api.ts
+++ b/public/script/profile/user-api.ts
@@ -1,4 +1,4 @@
-import { getJson, patchJson, postJson, getCurrentUserId, ApiError } from "../api/api-helpers";
+import { getJson, postJson, getCurrentUserId, ApiError } from "../api/api-helpers";
 import { CoinsResponseSchema, ProfileResponseSchema } from "shared";
 
 export async function getUserCoins(): Promise<number> {
@@ -25,25 +25,9 @@ export async function getUserProfile(): Promise<{ username: string; coins: numbe
     return body.profile;
 }
 
-export async function addUserCoins(amount: number): Promise<number> {
-    const userId = await getCurrentUserId();
-    const rawBody = await patchJson(`/api/users/${userId}/coins`, { add: amount }, {
-        errorFallbackKey: "api.user.addCoinsFailed"
-    });
-    return CoinsResponseSchema.parse(rawBody).coins;
-}
-
 export async function ensureDefaultAssets(): Promise<void> {
     const userId = await getCurrentUserId();
     await postJson(`/api/users/${userId}/inventory/default-assets`, undefined, {
         errorFallbackKey: "api.user.defaultAssetsFailed"
     });
-}
-
-export async function subtractUserCoins(amount: number): Promise<number> {
-    const userId = await getCurrentUserId();
-    const rawBody = await patchJson(`/api/users/${userId}/coins`, { subtract: amount }, {
-        errorFallbackKey: "api.user.subtractCoinsFailed"
-    });
-    return CoinsResponseSchema.parse(rawBody).coins;
 }

--- a/public/script/profile/user-api.ts
+++ b/public/script/profile/user-api.ts
@@ -1,4 +1,4 @@
-import { getJson, patchJson, postJson, getCurrentUserId, ApiError } from "./api-helpers";
+import { getJson, patchJson, postJson, getCurrentUserId, ApiError } from "../api/api-helpers";
 import { CoinsResponseSchema, ProfileResponseSchema } from "shared";
 
 export async function getUserCoins(): Promise<number> {

--- a/public/script/shop/shop.ts
+++ b/public/script/shop/shop.ts
@@ -2,9 +2,7 @@ import { requiredElement, initToggleModal } from "../shared/dom-helpers";
 import { loadShopAssets } from "./shop-assets";
 import type { Asset } from "shared";
 import { getShopAssets } from "../api/shop-api";
-import { getUserCoins } from "../profile/user-api";
-import { supabaseClient } from "../shared/supabase-client";
-import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+import { profileData } from "../profile/profile-data";
 import { getActiveCategory, renderCategoryTabs } from "../shared/category-tabs";
 import { formatNumber } from "../app/format";
 import { t } from "../app/i18n";
@@ -23,7 +21,11 @@ export const shopCloseBtn = requiredElement<HTMLButtonElement>("shop-modal-close
 
 export function initShop(): void {
     initToggleModal(shopModal, shopBtn, shopCloseBtn, openShop);
-    subscribeToCoinUpdates();
+    profileData.subscribe((state) => {
+        balance = state.coins;
+        renderCoinBalance();
+        if (shopModal.open) loadShopAssets();
+    });
     window.addEventListener("app:language-changed", () => {
         const activeCategory = getActiveCategory<AssetCategory | "all">(shopTabs, "shop-modal") ?? "all";
         renderShopTabs(["all", ...ASSET_CATEGORIES] as (AssetCategory | "all")[], activeCategory);
@@ -59,30 +61,10 @@ export function renderCoinBalance(): void {
 
 export async function loadCoinBalance(): Promise<void> {
     try {
-        balance = await getUserCoins();
+        await profileData.refreshCoins();
     } catch (error) {
         console.error("Coins konnten nicht aktualisiert werden:", error);
     }
-}
-
-async function subscribeToCoinUpdates(): Promise<void> {
-    const { data: { session } } = await supabaseClient.auth.getSession();
-    if (!session?.user?.id) return;
-
-    supabaseClient
-        .channel(`shop-coin-updates-${session.user.id}`)
-        .on(
-            "postgres_changes",
-            { event: "UPDATE", schema: "public", table: "profiles", filter: `id=eq.${session.user.id}` },
-            (payload: RealtimePostgresChangesPayload<{ coins?: number }>) => {
-                const nextBalance = (payload.new as { coins?: number })?.coins;
-                if (typeof nextBalance !== "number") return;
-                balance = nextBalance;
-                renderCoinBalance();
-                if (shopModal.open) loadShopAssets();
-            }
-        )
-        .subscribe();
 }
 
 

--- a/public/script/shop/shop.ts
+++ b/public/script/shop/shop.ts
@@ -2,7 +2,7 @@ import { requiredElement, initToggleModal } from "../shared/dom-helpers";
 import { loadShopAssets } from "./shop-assets";
 import type { Asset } from "shared";
 import { getShopAssets } from "../api/shop-api";
-import { getUserCoins } from "../api/user-api";
+import { getUserCoins } from "../profile/user-api";
 import { supabaseClient } from "../shared/supabase-client";
 import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
 import { getActiveCategory, renderCategoryTabs } from "../shared/category-tabs";

--- a/public/script/wheel/spin.ts
+++ b/public/script/wheel/spin.ts
@@ -6,7 +6,7 @@ import { getMultiplier, multiplierButton } from "./multiplier";
 import { wheelElement } from "./renderer";
 import { bulkAddToWheelBtn, getPlayerToggleButtons } from "../multiplayer/room-players-sidebar";
 import { getCurrentMode } from "../multiplayer/game-mode-strategy";
-import { profileName } from "../profile/profiles";
+import { profileName } from "../profile/profile-ui";
 import { MIN_ITEMS } from "../names/names-in-wheel-list-state";
 import { requiredElement } from "../shared/dom-helpers";
 

--- a/public/script/wheel/winner.ts
+++ b/public/script/wheel/winner.ts
@@ -3,7 +3,7 @@ import { getCurrentMode } from "../multiplayer/game-mode-strategy";
 import { awardCoins } from "../api/spin-api";
 import { getNamesInWheelList } from "../names/names-in-wheel-list";
 import { stopDrumRoll } from "./sound";
-import { refreshCoinDisplay } from "../profile/profiles";
+import { refreshCoinDisplay } from "../profile/profile-ui";
 import { showToast } from "../shared/toast";
 import { requiredElement } from "../shared/dom-helpers";
 import type { SpinConfig } from "./spin";

--- a/server/src/controllers/user-controller.ts
+++ b/server/src/controllers/user-controller.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ensureDefaultAssets, getUserCoins, getUserProfile, registerUser, addUserCoins, subtractUserCoins } from "../services/user-service";
+import { ensureDefaultAssets, getUserCoins, getUserProfile, registerUser } from "../services/user-service";
 import { asyncHandler } from "./response";
 import type { HttpRequest, HttpResponse } from "./response";
 import {
@@ -32,25 +32,6 @@ export const handleRegisterUser = asyncHandler(async (req: HttpRequest, res: Htt
 
 export const handleGetUserCoins = asyncHandler(async (req: HttpRequest, res: HttpResponse) => {
     const coins = await getUserCoins(req.params!.userId!);
-    res.status(200).json(CoinsResponseSchema.parse({ coins }));
-});
-
-const PatchCoinsRequestSchema = z.union([
-    z.object({ add: z.number() }).strict(),
-    z.object({ subtract: z.number() }).strict(),
-]);
-
-export const handlePatchUserCoins = asyncHandler(async (req: HttpRequest, res: HttpResponse) => {
-    const parsedBody = PatchCoinsRequestSchema.safeParse(req.body);
-    if (!parsedBody.success) {
-        res.status(400).json({ error: "Provide either { add } or { subtract }" });
-        return;
-    }
-
-    const userId = req.params!.userId!;
-    const coins = "add" in parsedBody.data
-        ? await addUserCoins(userId, parsedBody.data.add)
-        : await subtractUserCoins(userId, parsedBody.data.subtract);
     res.status(200).json(CoinsResponseSchema.parse({ coins }));
 });
 

--- a/server/src/routes/users-routes.ts
+++ b/server/src/routes/users-routes.ts
@@ -4,7 +4,6 @@ import {
     handleRegisterUser,
     handleUserProfile,
     handleGetUserCoins,
-    handlePatchUserCoins,
     handleEnsureDefaultAssets
 } from "../controllers/user-controller";
 import {
@@ -23,7 +22,6 @@ usersRoutes.param("userId", requireSelf);
 usersRoutes.post("/", handleRegisterUser);
 usersRoutes.get("/:userId", handleUserProfile);
 usersRoutes.get("/:userId/coins", handleGetUserCoins);
-usersRoutes.patch("/:userId/coins", handlePatchUserCoins);
 usersRoutes.get("/:userId/inventory/assets", handleGetOwnedAssets);
 usersRoutes.post("/:userId/inventory/default-assets", handleEnsureDefaultAssets);
 usersRoutes.get("/:userId/inventory/selected-assets", handleGetSelectedAssets);

--- a/server/src/services/shop-service.ts
+++ b/server/src/services/shop-service.ts
@@ -4,7 +4,8 @@ import {
     listAssets,
     userOwnsAsset
 } from "../repositories/asset-repository";
-import { getCoinsByUserId, updateCoinsByUserId } from "../repositories/profile-repository";
+import { getCoinsByUserId } from "../repositories/profile-repository";
+import { subtractCoins } from "./user-service";
 import { AppError } from "../lib/errors";
 import type { Asset, PurchaseResponseBody } from "shared";
 
@@ -34,8 +35,7 @@ export async function purchaseAsset(userId: string, assetId: string): Promise<Pu
 
     await createAssetOwnership(userId, assetId);
 
-    const remainingCoins = currentCoins - asset.price_coins;
-    await updateCoinsByUserId(userId, remainingCoins);
+    const remainingCoins = await subtractCoins(userId, asset.price_coins);
 
     return {
         success: true,

--- a/server/src/services/spin-service.ts
+++ b/server/src/services/spin-service.ts
@@ -3,11 +3,10 @@ import { getSecureRandomNumber } from "../lib/random";
 import { AppError } from "../lib/errors";
 import {
     getProfileByUserId,
-    getCoinsByUserId,
-    updateCoinsByUserId,
     getUserIdByUsername,
 } from "../repositories/profile-repository";
 import { insertSpinToken, findValidSpinToken, markSpinTokenUsed } from "../repositories/room-repository";
+import { addCoins } from "./user-service";
 import type { SpinRandomResponseBody, AwardCoinsResponseBody } from "shared";
 
 function getRandomWheelSpinNumber(): number {
@@ -62,9 +61,4 @@ export async function awardCoins(userId: string, spinToken: string, winnerName: 
 
     console.log(`[coins] Winner: ${winnerName} → nicht im System, keine Coins`);
     return { spinnerCoins, winnerCoins: 0 };
-}
-
-async function addCoins(userId: string, amount: number): Promise<void> {
-    const currentCoins = await getCoinsByUserId(userId);
-    await updateCoinsByUserId(userId, currentCoins + amount);
 }

--- a/server/src/services/user-service.ts
+++ b/server/src/services/user-service.ts
@@ -16,13 +16,20 @@ export async function getUserProfile(userId: string): Promise<Profile | null> {
     return getProfileByUserId(userId);
 }
 
-export async function addUserCoins(userId: string, amount: number): Promise<number> {
-    if (!Number.isFinite(amount) || amount <= 0) {
-        throw new AppError("Invalid amount", 400);
-    }
-
+export async function addCoins(userId: string, amount: number): Promise<number> {
     const currentCoins = await getCoinsByUserId(userId);
     const newBalance = currentCoins + amount;
+    await updateCoinsByUserId(userId, newBalance);
+    return newBalance;
+}
+
+export async function subtractCoins(userId: string, amount: number): Promise<number> {
+    const currentCoins = await getCoinsByUserId(userId);
+    if (currentCoins < amount) {
+        throw new AppError("Not enough coins", 400);
+    }
+
+    const newBalance = currentCoins - amount;
     await updateCoinsByUserId(userId, newBalance);
     return newBalance;
 }
@@ -34,19 +41,4 @@ export async function registerUser(userId: string, username: string, email: stri
 
 export async function ensureDefaultAssets(userId: string): Promise<void> {
     await assignDefaultAssets(userId);
-}
-
-export async function subtractUserCoins(userId: string, amount: number): Promise<number> {
-    if (!Number.isFinite(amount) || amount <= 0) {
-        throw new AppError("Invalid amount", 400);
-    }
-
-    const currentCoins = await getCoinsByUserId(userId);
-    if (currentCoins < amount) {
-        throw new AppError("Not enough coins", 400);
-    }
-
-    const newBalance = currentCoins - amount;
-    await updateCoinsByUserId(userId, newBalance);
-    return newBalance;
 }


### PR DESCRIPTION
**1. Zentrale Zustandsverwaltung (`profile-data.ts`)**  
Eine `ProfileData`-Klasse als Single Source of Truth für Username, Coins und Login-Status. Sie kapselt Session-Abfrage, API-Calls und die Supabase-Realtime-Subscription — niemand sonst greift mehr direkt auf diese Dinge zu.

**2. Reaktive Schnittstelle (Observer Pattern)**  
`subscribe()`/`setState()` sorgen dafür, dass sich beliebige UI-Teile bei `ProfileData` anmelden und automatisch benachrichtigt werden, sobald sich State ändert — egal ob durch einen API-Call oder ein Supabase-Event.

**3. UI ausgelagert (`profile-ui.ts`)**  
DOM-Referenzen, Rendering und Event-Listener leben jetzt in einer eigenen Datei, die selbst keinen Zustand mehr hält, sondern nur noch auf `ProfileData` reagiert und deren Methoden aufruft (z. B. `signOut()`).

**4. Konsumenten umgestellt**  
`main.ts`, `shop.ts`, `spin.ts` und `winner.ts` beziehen Profil-Daten jetzt über `ProfileData` statt über die alte `profiles.ts` oder eigene API-Calls. Der Shop verlor dabei auch seine eigene, doppelte Supabase-Coin-Subscription.

**5. Cleanup**  
Die alte `profiles.ts` gelöscht, verwaiste Imports entfernt, TypeScript-Check sauber.
